### PR TITLE
Update ssh_autodetect.py

### DIFF
--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -186,6 +186,18 @@ SSH_MAPPER_DICT = {
         "priority": 99,
         "dispatch": "_autodetect_std",
     },
+    "extreme_voss": {
+        "cmd": "show sys-info",
+        "search_patterns": [r"VSP|vsp"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
+    "extreme_boss": {
+        "cmd": "show system",
+        "search_patterns": [r"Ethernet Routing Switch"],
+        "priority": 99,
+        "dispatch": "_autodetect_std",
+    },
     "extreme_netiron": {
         "cmd": "show version",
         "search_patterns": [r"(NetIron|MLX)"],


### PR DESCRIPTION
I have updated the ssh_autodetect.py for extreme voss and exos switching models. made the change to the SSHMapper.